### PR TITLE
Refactor is_m3u8_url method to use urlparse for improved URL validation

### DIFF
--- a/pym3u8downloader/utility_class.py
+++ b/pym3u8downloader/utility_class.py
@@ -139,7 +139,8 @@ class UtilityClass:
        :rtype: bool
        """
         validate_type(value, str, 'value should be a string.')
-        return value.endswith('.m3u8')
+        parsed_url = urlparse(value)
+        return parsed_url.path.endswith('.m3u8')
 
     @staticmethod
     def is_space_available(folder_path: str, required: int) -> bool:


### PR DESCRIPTION
Some websites require additional query parameters to access .m3u8 files. Therefore, instead of checking the entire URL, we should check if the path ends with ".m3u8".

For example: https://link.to.website/hls2/01/01505/index-f3-v1-a1.m3u8?params1=value1&params2=value2